### PR TITLE
Fixing easygit bash completion, mostly by accident.

### DIFF
--- a/bash-completion-eg.sh
+++ b/bash-completion-eg.sh
@@ -208,6 +208,9 @@ _eg ()
 {
   local i c=1 command __git_dir
 
+  local cur words cword prev
+  _get_comp_words_by_ref -n =: cur words cword prev
+
   while [ $c -lt $COMP_CWORD ]; do
     i="${COMP_WORDS[c]}"
     case "$i" in


### PR DESCRIPTION
I was poking around at the easygit bash completion tonight, and I accidentally seem to have fixed it.

Completion is this gnarly mess of what amount to global variables (though bash tricks you by declaring them as 'local'!). I think they changed the way some data was passed around between when the `eg` completion script was last updated and now.

I'll use my updated copy of easygit for a couple of days to make sure everything seems to be working, but honestly it can't be any worse than it was, which was totally broken...
