### PR TITLE
fix eg status (closes #3)

### DIFF
--- a/eg
+++ b/eg
@@ -6511,7 +6511,7 @@ sub run {
   $self->{special_state} = RepoUtil::get_special_state($self->{git_dir});
 
   @ARGV = Util::quote_args(@ARGV);
-  return ExecUtil::execute("$git_cmd status @ARGV", ignore_ret => 1);
+  return ExecUtil::execute("$git_cmd -c status.displayCommentPrefix=true status @ARGV", ignore_ret => 1);
 }
 
 sub postprocess {
@@ -6573,7 +6573,7 @@ sub postprocess {
     } elsif ($cur_state < 0) {
       next if $line !~ m/^# (.+)/;
       push(@basic_info, $1);
-    } elsif ($line =~ m/^no changes added to commit/ ||
+    } elsif ($line =~ m/^no(?:thing|\s+changes) added to commit/ ||
              $line =~ m/^# Untracked files not listed/) {
       next;  # Skip this line
     } elsif ($line =~ m#^(?:\e\[.*?m)?diff --git a/#) {


### PR DESCRIPTION
The output of `git status` [changed](https://github.com/git/git/commit/2556b9962e7c0353d562b7bf70eed11d8f29d0b0) in 1.8.5: the leading `core.commentChar` prefix ("#" by default) was removed.

Fortunately, there's a config option to restore it (`status.displayCommentPrefix=true`) and git provides a way to set a config option while executing a command:

```
git -c name=value command --options ...
```

So that mostly [restores the expected output](https://github.com/dfabulich/easygit/issues/3).

However, there have been other changes in the output since the status parser was last updated. There's one other fix here — "no changes added" is now "nothing added" — but others may be needed now and more will likely be needed in future.

The underlying issue is that this info is being parsed out of human-readable output rather than a machine-readable format like that produced by `git status --porcelain`.
